### PR TITLE
Fix incrementing version number in autoconf/automake projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
+## [Unreleased]
+### Changed
+ - Invoke autoreconf in automake projects when incrementing version number
+
 ## [2.2.0] - 2017-06-05
 
 ### Changed
@@ -64,6 +68,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [1.0.0] - 2016-12-22
 
+[Unreleased]: https://github.com/alkuna/omgf/compare/master...dev
 [2.2.0]: https://github.com/InternetGuru/omgf/compare/v2.1.2...v2.2.0
 [2.1.2]: https://github.com/InternetGuru/omgf/compare/v2.1.1...v2.1.2
 [2.1.1]: https://github.com/InternetGuru/omgf/compare/v2.1.0...v2.1.1

--- a/omgf
+++ b/omgf
@@ -892,6 +892,7 @@ function main {
   function gf_commit_version {
     msg_start "Increment version number to '$major.$minor.$patch'"
     echo "$major.$minor.$patch" > "$OMGF_VERSION"
+    [[ -s configure.ac ]] && autoreconf -f
     git commit -am "Increment version number" >/dev/null || return 1
     msg_end "$DONE"
   }


### PR DESCRIPTION
On development projects using GNU autoconf and automake tools, the version number should be updated in _configure.ac_ and _configure_ files when hot-fixing or releasing with omgf.

This patch checks for existence of configure.ac file and invokes `autoreconf -f` command to regenerate the configure script before adding and committing changes.

Development projects using autoconf and automake should be changed to fully advance this patch in the following sence:

1. A configure.ac file has to read the version number from VERSION file using proper m4 macro, e.g.:
```
AC_INIT(project,` m4_esyscmd_s([cat VERSION]), Author <author@email.com>)
```
2. autom4te.cache directory generated by autoreconf is not intended for commit, thus it should be added to .gitignore.

